### PR TITLE
Support for periodic timers and custom signal handlers

### DIFF
--- a/examples/uloop-example.lua
+++ b/examples/uloop-example.lua
@@ -24,6 +24,23 @@ uloop.timer(function() print("2000 ms timer run"); end, 2000)
 -- timer example 3 (will never run)
 uloop.timer(function() print("3000 ms timer run"); end, 3000):cancel()
 
+-- periodic interval timer
+local intv
+intv = uloop.interval(function()
+	print(string.format("Interval expiration #%d - %dms until next expiration",
+		intv:expirations(), intv:remaining()))
+
+	-- after 5 expirations, lower interval to 500ms
+	if intv:expirations() >= 5 then
+		intv:set(500)
+	end
+
+	-- cancel after 10 expirations
+	if intv:expirations() >= 10 then
+		intv:cancel()
+	end
+end, 1000)
+
 -- process
 function p1(r)
 	print("Process 1 completed")

--- a/examples/uloop-example.lua
+++ b/examples/uloop-example.lua
@@ -63,6 +63,22 @@ uloop.timer(
 	end, 2000
 )
 
+-- SIGINT handler
+uloop.signal(function(signo)
+	print(string.format("Terminating on SIGINT (#%d)!", signo))
+
+	-- end uloop to terminate program
+	uloop.cancel()
+end, uloop.SIGINT)
+
+local sig
+sig = uloop.signal(function(signo)
+	print(string.format("Got SIGUSR2 (#%d)!", signo))
+
+	-- remove signal handler, next SIGUSR2 will terminate program
+	sig:delete()
+end, uloop.SIGUSR2)
+
 -- Keep udp_ev reference, events will be gc'd, even if the callback is still referenced
 -- .delete will manually untrack.
 udp_ev = uloop.fd_add(udp, function(ufd, events)

--- a/uloop-epoll.c
+++ b/uloop-epoll.c
@@ -104,3 +104,83 @@ static int uloop_fetch_events(int timeout)
 
 	return nfds;
 }
+
+static void dispatch_timer(struct uloop_fd *u, unsigned int events)
+{
+	if (!(events & ULOOP_READ))
+		return;
+
+	uint64_t fired;
+
+	if (read(u->fd, &fired, sizeof(fired)) != sizeof(fired))
+		return;
+
+	struct uloop_interval *tm = container_of(u, struct uloop_interval, private.ufd);
+
+	tm->expirations += fired;
+	tm->cb(tm);
+}
+
+static int timer_register(struct uloop_interval *tm, unsigned int msecs)
+{
+	if (!tm->private.ufd.registered) {
+		int fd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC|TFD_NONBLOCK);
+
+		if (fd == -1)
+			return -1;
+
+		tm->private.ufd.fd = fd;
+		tm->private.ufd.cb = dispatch_timer;
+	}
+
+	struct itimerspec spec = {
+		.it_value = {
+			.tv_sec = msecs / 1000,
+			.tv_nsec = (msecs % 1000) * 1000000
+		},
+		.it_interval = {
+			.tv_sec = msecs / 1000,
+			.tv_nsec = (msecs % 1000) * 1000000
+		}
+	};
+
+	if (timerfd_settime(tm->private.ufd.fd, 0, &spec, NULL) == -1)
+		goto err;
+
+	if (uloop_fd_add(&tm->private.ufd, ULOOP_READ) == -1)
+		goto err;
+
+	return 0;
+
+err:
+	uloop_fd_delete(&tm->private.ufd);
+	close(tm->private.ufd.fd);
+	memset(&tm->private.ufd, 0, sizeof(tm->private.ufd));
+
+	return -1;
+}
+
+static int timer_remove(struct uloop_interval *tm)
+{
+	int ret = __uloop_fd_delete(&tm->private.ufd);
+
+	if (ret == 0) {
+		close(tm->private.ufd.fd);
+		memset(&tm->private.ufd, 0, sizeof(tm->private.ufd));
+	}
+
+	return ret;
+}
+
+static int64_t timer_next(struct uloop_interval *tm)
+{
+	struct itimerspec spec;
+
+	if (!tm->private.ufd.registered)
+		return -1;
+
+	if (timerfd_gettime(tm->private.ufd.fd, &spec) == -1)
+		return -1;
+
+	return spec.it_value.tv_sec * 1000 + spec.it_value.tv_nsec / 1000000;
+}

--- a/uloop-kqueue.c
+++ b/uloop-kqueue.c
@@ -103,6 +103,23 @@ static int __uloop_fd_delete(struct uloop_fd *fd)
 	return register_poll(fd, 0);
 }
 
+static int64_t get_timestamp_us(void)
+{
+#ifdef CLOCK_MONOTONIC
+	struct timespec ts = { 0, 0 };
+
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+
+	return ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
+#else
+	struct timeval tv = { 0, 0 };
+
+	gettimeofday(&tv, NULL);
+
+	return tv.tv_sec * 1000000 + tv.tv_usec;
+#endif
+}
+
 static int uloop_fetch_events(int timeout)
 {
 	struct timespec ts;
@@ -115,6 +132,16 @@ static int uloop_fetch_events(int timeout)
 
 	nfds = kevent(poll_fd, NULL, 0, events, ARRAY_SIZE(events), timeout >= 0 ? &ts : NULL);
 	for (n = 0; n < nfds; n++) {
+		if (events[n].filter == EVFILT_TIMER) {
+			struct uloop_interval *tm = events[n].udata;
+
+			tm->private.time.fired = get_timestamp_us();
+			tm->expirations += events[n].data;
+			tm->cb(tm);
+
+			continue;
+		}
+
 		struct uloop_fd_event *cur = &cur_fds[n];
 		struct uloop_fd *u = events[n].udata;
 		unsigned int ev = 0;
@@ -147,4 +174,36 @@ static int uloop_fetch_events(int timeout)
 		}
 	}
 	return nfds;
+}
+
+static int timer_register(struct uloop_interval *tm, unsigned int msecs)
+{
+	struct kevent ev;
+
+	tm->private.time.msecs = msecs;
+	tm->private.time.fired = get_timestamp_us();
+
+	EV_SET(&ev, (uintptr_t)tm, EVFILT_TIMER, EV_ADD, NOTE_USECONDS, msecs * 1000, tm);
+
+	return kevent(poll_fd, &ev, 1, NULL, 0, NULL);
+}
+
+static int timer_remove(struct uloop_interval *tm)
+{
+	struct kevent ev;
+
+	EV_SET(&ev, (uintptr_t)tm, EVFILT_TIMER, EV_DELETE, 0, 0, NULL);
+
+	return kevent(poll_fd, &ev, 1, NULL, 0, NULL);
+}
+
+static int64_t timer_next(struct uloop_interval *tm)
+{
+	int64_t t1 = tm->private.time.fired;
+	int64_t t2 = get_timestamp_us();
+
+	while (t1 < t2)
+		t1 += tm->private.time.msecs * 1000;
+
+	return (t1 - t2) / 1000;
 }

--- a/uloop.c
+++ b/uloop.c
@@ -57,6 +57,7 @@ static struct uloop_fd_stack *fd_stack = NULL;
 
 static struct list_head timeouts = LIST_HEAD_INIT(timeouts);
 static struct list_head processes = LIST_HEAD_INIT(processes);
+static struct list_head signals = LIST_HEAD_INIT(signals);
 
 static int poll_fd = -1;
 bool uloop_cancelled = false;
@@ -80,18 +81,41 @@ int uloop_fd_add(struct uloop_fd *sock, unsigned int flags);
 #include "uloop-epoll.c"
 #endif
 
-static void waker_consume(struct uloop_fd *fd, unsigned int events)
+static void set_signo(uint64_t *signums, int signo)
 {
-	char buf[4];
+	if (signo >= 1 && signo <= 64)
+		*signums |= (1u << (signo - 1));
+}
 
-	while (read(fd->fd, buf, 4) > 0)
-		;
+static bool get_signo(uint64_t signums, int signo)
+{
+	return (signo >= 1) && (signo <= 64) && (signums & (1u << (signo - 1)));
+}
+
+static void signal_consume(struct uloop_fd *fd, unsigned int events)
+{
+	struct uloop_signal *usig, *usig_next;
+	uint64_t signums = 0;
+	uint8_t buf[32];
+	ssize_t nsigs;
+
+	do {
+		nsigs = read(fd->fd, buf, sizeof(buf));
+
+		for (ssize_t i = 0; i < nsigs; i++)
+			set_signo(&signums, buf[i]);
+	}
+	while (nsigs > 0);
+
+	list_for_each_entry_safe(usig, usig_next, &signals, list)
+		if (get_signo(signums, usig->signo))
+			usig->cb(usig);
 }
 
 static int waker_pipe = -1;
 static struct uloop_fd waker_fd = {
 	.fd = -1,
-	.cb = waker_consume,
+	.cb = signal_consume,
 };
 
 static void waker_init_fd(int fd)
@@ -115,7 +139,7 @@ static int waker_init(void)
 	waker_pipe = fds[1];
 
 	waker_fd.fd = fds[0];
-	waker_fd.cb = waker_consume;
+	waker_fd.cb = signal_consume;
 	uloop_fd_add(&waker_fd, ULOOP_READ);
 
 	return 0;
@@ -438,10 +462,15 @@ int64_t uloop_interval_remaining(struct uloop_interval *timer)
 	return timer_next(timer);
 }
 
-static void uloop_signal_wake(void)
+static void uloop_signal_wake(int signo)
 {
+	uint8_t sigbyte = signo;
+
+	if (signo == ECHILD)
+		do_sigchld = true;
+
 	do {
-		if (write(waker_pipe, "w", 1) < 0) {
+		if (write(waker_pipe, &sigbyte, 1) < 0) {
 			if (errno == EINTR)
 				continue;
 		}
@@ -453,13 +482,7 @@ static void uloop_handle_sigint(int signo)
 {
 	uloop_status = signo;
 	uloop_cancelled = true;
-	uloop_signal_wake();
-}
-
-static void uloop_sigchld(int signo)
-{
-	do_sigchld = true;
-	uloop_signal_wake();
+	uloop_signal_wake(signo);
 }
 
 static void uloop_install_handler(int signum, void (*handler)(int), struct sigaction* old, bool add)
@@ -516,9 +539,53 @@ static void uloop_setup_signals(bool add)
 	uloop_install_handler(SIGTERM, uloop_handle_sigint, &old_sigterm, add);
 
 	if (uloop_handle_sigchld)
-		uloop_install_handler(SIGCHLD, uloop_sigchld, &old_sigchld, add);
+		uloop_install_handler(SIGCHLD, uloop_signal_wake, &old_sigchld, add);
 
 	uloop_ignore_signal(SIGPIPE, add);
+}
+
+int uloop_signal_add(struct uloop_signal *s)
+{
+	struct list_head *h = &signals;
+	struct uloop_signal *tmp;
+	struct sigaction sa;
+
+	if (s->pending)
+		return -1;
+
+	list_for_each_entry(tmp, &signals, list) {
+		if (tmp->signo > s->signo) {
+			h = &tmp->list;
+			break;
+		}
+	}
+
+	list_add_tail(&s->list, h);
+	s->pending = true;
+
+	sigaction(s->signo, NULL, &s->orig);
+
+	if (s->orig.sa_handler != uloop_signal_wake) {
+		sa.sa_handler = uloop_signal_wake;
+		sa.sa_flags = 0;
+		sigaction(s->signo, &sa, NULL);
+	}
+
+	return 0;
+}
+
+int uloop_signal_delete(struct uloop_signal *s)
+{
+	if (!s->pending)
+		return -1;
+
+	list_del(&s->list);
+	s->pending = false;
+
+	if (s->orig.sa_handler != uloop_signal_wake)
+		sigaction(s->signo, &s->orig, NULL);
+
+	return 0;
 }
 
 int uloop_get_next_timeout(void)

--- a/uloop.c
+++ b/uloop.c
@@ -36,6 +36,7 @@
 #endif
 #ifdef USE_EPOLL
 #include <sys/epoll.h>
+#include <sys/timerfd.h>
 #endif
 #include <sys/wait.h>
 
@@ -420,6 +421,21 @@ static void uloop_handle_processes(void)
 		}
 	}
 
+}
+
+int uloop_interval_set(struct uloop_interval *timer, unsigned int msecs)
+{
+	return timer_register(timer, msecs);
+}
+
+int uloop_interval_cancel(struct uloop_interval *timer)
+{
+	return timer_remove(timer);
+}
+
+int64_t uloop_interval_remaining(struct uloop_interval *timer)
+{
+	return timer_next(timer);
 }
 
 static void uloop_signal_wake(void)

--- a/uloop.h
+++ b/uloop.h
@@ -35,10 +35,12 @@
 struct uloop_fd;
 struct uloop_timeout;
 struct uloop_process;
+struct uloop_interval;
 
 typedef void (*uloop_fd_handler)(struct uloop_fd *u, unsigned int events);
 typedef void (*uloop_timeout_handler)(struct uloop_timeout *t);
 typedef void (*uloop_process_handler)(struct uloop_process *c, int ret);
+typedef void (*uloop_interval_handler)(struct uloop_interval *t);
 
 #define ULOOP_READ		(1 << 0)
 #define ULOOP_WRITE		(1 << 1)
@@ -83,6 +85,20 @@ struct uloop_process
 	pid_t pid;
 };
 
+struct uloop_interval
+{
+	uloop_interval_handler cb;
+	uint64_t expirations;
+
+	union {
+		struct uloop_fd ufd;
+		struct {
+			int64_t fired;
+			unsigned int msecs;
+		} time;
+	} private;
+};
+
 extern bool uloop_cancelled;
 extern bool uloop_handle_sigchld;
 extern uloop_fd_handler uloop_fd_set_cb;
@@ -99,6 +115,10 @@ int64_t uloop_timeout_remaining64(struct uloop_timeout *timeout);
 
 int uloop_process_add(struct uloop_process *p);
 int uloop_process_delete(struct uloop_process *p);
+
+int uloop_interval_set(struct uloop_interval *timer, unsigned int msecs);
+int uloop_interval_cancel(struct uloop_interval *timer);
+int64_t uloop_interval_remaining(struct uloop_interval *timer);
 
 bool uloop_cancelling(void);
 

--- a/uloop.h
+++ b/uloop.h
@@ -36,11 +36,13 @@ struct uloop_fd;
 struct uloop_timeout;
 struct uloop_process;
 struct uloop_interval;
+struct uloop_signal;
 
 typedef void (*uloop_fd_handler)(struct uloop_fd *u, unsigned int events);
 typedef void (*uloop_timeout_handler)(struct uloop_timeout *t);
 typedef void (*uloop_process_handler)(struct uloop_process *c, int ret);
 typedef void (*uloop_interval_handler)(struct uloop_interval *t);
+typedef void (*uloop_signal_handler)(struct uloop_signal *s);
 
 #define ULOOP_READ		(1 << 0)
 #define ULOOP_WRITE		(1 << 1)
@@ -99,6 +101,16 @@ struct uloop_interval
 	} private;
 };
 
+struct uloop_signal
+{
+	struct list_head list;
+	struct sigaction orig;
+	bool pending;
+
+	uloop_signal_handler cb;
+	int signo;
+};
+
 extern bool uloop_cancelled;
 extern bool uloop_handle_sigchld;
 extern uloop_fd_handler uloop_fd_set_cb;
@@ -119,6 +131,9 @@ int uloop_process_delete(struct uloop_process *p);
 int uloop_interval_set(struct uloop_interval *timer, unsigned int msecs);
 int uloop_interval_cancel(struct uloop_interval *timer);
 int64_t uloop_interval_remaining(struct uloop_interval *timer);
+
+int uloop_signal_add(struct uloop_signal *s);
+int uloop_signal_delete(struct uloop_signal *s);
 
 bool uloop_cancelling(void);
 


### PR DESCRIPTION
This PR introduces two commits:

---

uloop: add support for user defined signal handlers

Reuse and extend the existing signal waker pipe mechanism to add user
defined signal handling functionality to uloop.

This commit introduces two new api functions `uloop_signal_add()` and
`uloop_signal_remove()` along with a new structure type `uloop_signal`
to allow adding and removing arbitrary signal handlers.

Registered signal handlers are maintained in a linked list and matched
by their signo member value which allows registering multiple handlers
for the same signal numbers.

Upon registering a new signal handler, the existing handler is saved
in the `uloop_signal` structure. When removing the user defined signal
handler, the original behavior is restored.

The Lua binding has been updated as well to support the new signal
handler mechanism.

---

uloop: add support for interval timers

So far, the only way to implement periodic interval timers was to use
one-shot uloop_timeout timers which are rearmed within their completion
callback immediately on expiration.

While simple, this approach is not very precise and interval lengths will
slowly drift over time, due to callback execution overhead, scheduling
granularity etc.

In order to make uloop provide stable and precise interval timer
capabilities, this commit introduces a new `uloop_interval` structure
along with the new related `uloop_interval_set()`, `uloop_interval_cancel()`
and `uloop_interval_remaining()` api functions.

Periodic timers are implemented using the timerfd facility an Linux and
kqueue EVFILT_TIMER events on macOS/BSD.

The Lua binding has been updated to include support for the new timer type
as well.