### PR TITLE
libubox: Add anonymous strings, ints, et al in arrays

### DIFF
--- a/sh/jshn.sh
+++ b/sh/jshn.sh
@@ -150,10 +150,32 @@ json_add_string() {
 	_json_add_generic string "$1" "$2" "$cur"
 }
 
+json_push_string() {
+	local cur
+	_json_get_var cur JSON_CUR
+	[ "${cur%%[0-9]*}" = "J_A" ] || {
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not in an array" >&2
+		return 1
+	}
+	_json_add_generic string "" "$1" "$cur"
+}
+
 json_add_int() {
 	local cur
 	_json_get_var cur JSON_CUR
 	_json_add_generic int "$1" "$2" "$cur"
+}
+
+json_push_int() {
+	local cur
+	_json_get_var cur JSON_CUR
+	[ "${cur%%[0-9]*}" = "J_A" ] || {
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not in an array" >&2
+		return 1
+	}
+	_json_add_generic int "" "$1" "$cur"
 }
 
 json_add_boolean() {
@@ -162,16 +184,49 @@ json_add_boolean() {
 	_json_add_generic boolean "$1" "$2" "$cur"
 }
 
+json_push_boolean() {
+	local cur
+	_json_get_var cur JSON_CUR
+	[ "${cur%%[0-9]*}" = "J_A" ] || {
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not in an array" >&2
+		return 1
+	}
+	_json_add_generic boolean "" "$1" "$cur"
+}
+
 json_add_double() {
 	local cur
 	_json_get_var cur JSON_CUR
 	_json_add_generic double "$1" "$2" "$cur"
 }
 
+json_push_double() {
+	local cur
+	_json_get_var cur JSON_CUR
+	[ "${cur%%[0-9]*}" = "J_A" ] || {
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not in an array" >&2
+		return 1
+	}
+	_json_add_generic double "" "$1" "$cur"
+}
+
 json_add_null() {
 	local cur
 	_json_get_var cur JSON_CUR
 	_json_add_generic null "$1" "" "$cur"
+}
+
+json_push_null() {
+	local cur
+	_json_get_var cur JSON_CUR
+	[ "${cur%%[0-9]*}" = "J_A" ] || {
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not in an array" >&2
+		return 1
+	}
+	_json_add_generic null "" "" "$cur"
 }
 
 json_add_fields() {

--- a/sh/jshn.sh
+++ b/sh/jshn.sh
@@ -236,6 +236,7 @@ json_dump() {
 }
 
 json_get_type() {
+	# target=$2
 	local __dest="$1"
 	local __cur
 
@@ -305,11 +306,11 @@ json_select() {
 	local type
 	local cur
 
-	[ -z "$1" ] && {
+	[ -z "$target" ] && {
 		_json_set_var JSON_CUR "J_V"
 		return 0
 	}
-	[[ "$1" == ".." ]] && {
+	[[ "$target" == ".." ]] && {
 		_json_get_var cur JSON_CUR
 		_json_get_var cur "U_$cur"
 		_json_set_var JSON_CUR "$cur"
@@ -330,6 +331,8 @@ json_select() {
 }
 
 json_is_a() {
+	# target=$1
+	# type=$2
 	local type
 
 	json_get_type type "$1"

--- a/sh/jshn.sh
+++ b/sh/jshn.sh
@@ -323,7 +323,7 @@ json_select() {
 		;;
 		*)
 			[ -n "$_json_no_warning" ] || \
-				echo "WARNING: Variable '$target' does not exist or is not an array/object"
+				echo "WARNING: Variable '$target' does not exist or is not an array/object" >&2
 			return 1
 		;;
 	esac

--- a/tests/shunit2/tests.sh
+++ b/tests/shunit2/tests.sh
@@ -452,6 +452,31 @@ test_jshn_add_multi() {
 	set -u
 }
 
+test_jshn_push_stuff() {
+	JSON_PREFIX="${JSON_PREFIX:-}"
+	. ../../sh/jshn.sh
+
+	set +u
+
+	# Test an array with anonymous strings, ints, booleans, doubles, and null in it
+	json_init
+	json_add_array "arr"
+
+	# first element uses the legacy method with no name
+	json_add_string "" "first"
+
+	# the rest use the new functions
+	json_push_string "second"
+	json_push_int 42
+	json_push_boolean true
+	json_push_double 3.141592
+	json_push_null
+
+	assertEquals '{ "arr": [ "first", "second", 42, false, 3.1415920000000002, null ] }' "$(json_dump)"
+
+	set -u
+}
+
 test_jshn_append_via_json_script() {
 	JSON_PREFIX="${JSON_PREFIX:-}"
 	. ../../sh/jshn.sh


### PR DESCRIPTION
You can have a "name" in an array member without an associated value.