### PR TITLE
remove C++ json lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,8 @@ OPTION(BUILD_LUA "build Lua plugin" ON)
 OPTION(BUILD_EXAMPLES "build examples" ON)
 
 INCLUDE(FindPkgConfig)
-PKG_SEARCH_MODULE(JSONC json-c)
-IF(JSONC_FOUND)
-  ADD_DEFINITIONS(-DJSONC)
-  INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
-ENDIF()
+PKG_SEARCH_MODULE(JSONC json-c REQUIRED)
+INCLUDE_DIRECTORIES(${JSONC_INCLUDE_DIRS})
 
 SET(SOURCES avl.c avl-cmp.c blob.c blobmsg.c uloop.c usock.c ustream.c ustream-fd.c vlist.c utils.c safe_list.c runqueue.c md5.c kvlist.c ulog.c base64.c udebug.c udebug-remote.c)
 

--- a/blobmsg_json.c
+++ b/blobmsg_json.c
@@ -17,11 +17,7 @@
 #include "blobmsg.h"
 #include "blobmsg_json.h"
 
-#ifdef JSONC
-	#include <json.h>
-#else
-	#include <json/json.h>
-#endif
+#include <json.h>
 
 bool blobmsg_add_object(struct blob_buf *b, json_object *obj)
 {

--- a/jshn.c
+++ b/jshn.c
@@ -13,12 +13,7 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
-#ifdef JSONC
-        #include <json.h>
-#else
-        #include <json/json.h>
-#endif
-
+#include <json.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Not only is it unneeded, it doesn't even compile without a C++ compiler.

ping @Ansuel

Originally from https://patchwork.ozlabs.org/project/openwrt/patch/20201225011158.35592-1-rosenp@gmail.com/ which was completely ignored.