### PR TITLE
jshn.sh: Drop extraneous space when appending values to variable

### DIFF
--- a/sh/jshn.sh
+++ b/sh/jshn.sh
@@ -23,7 +23,7 @@ __jshn_raw_append() {
 _jshn_append() {
 	# var=$1
 	local _a_value="$2"
-	eval "${JSON_PREFIX}$1=\"\${${JSON_PREFIX}$1} \$_a_value\""
+	eval "${JSON_PREFIX}$1=\"\${${JSON_PREFIX}$1}\${${JSON_PREFIX}$1:+ }\$_a_value\""
 }
 
 _get_var() {


### PR DESCRIPTION
fixes: issue #15