### PR TITLE
uloop: fix removing interval timer that fired at that time

### DIFF
--- a/uloop-epoll.c
+++ b/uloop-epoll.c
@@ -162,7 +162,10 @@ err:
 
 static int timer_remove(struct uloop_interval *tm)
 {
-	int ret = __uloop_fd_delete(&tm->priv.ufd);
+	if (!tm->priv.ufd.registered)
+		return 0;
+
+	int ret = uloop_fd_delete(&tm->priv.ufd);
 
 	if (ret == 0) {
 		close(tm->priv.ufd.fd);


### PR DESCRIPTION
This tries to fix the issue outlined in the commit message.

Note that I only changed the epoll-based backend of uloop. I'm not familiar with kqueue, and I'm not even sure the issue is even possible there...

cc: @nbd168 and @jow- since you guys seem to have been involved with the interval timer code