### PR TITLE
tests: shunit2: add test for _jshn_append via JSON script

### DIFF
--- a/tests/shunit2/tests.sh
+++ b/tests/shunit2/tests.sh
@@ -452,4 +452,25 @@ test_jshn_add_multi() {
 	set -u
 }
 
+test_jshn_append_via_json_script() {
+	JSON_PREFIX="${JSON_PREFIX:-}"
+	. ../../sh/jshn.sh
+
+	# __SHUNIT_SHELL_FLAGS='u' results in 'line 6: JSON_UNSET: unbound variable' in json_cleanup()
+	set +u
+
+	# Test appending first key to empty variable without leading space
+	json_init
+	json_add_string "first" "value1"
+	json_get_keys keys
+	assertEquals "first" "$keys"
+
+	# Test appending second key should maintain no leading space on first key
+	json_add_string "second" "value2"
+	json_get_keys keys
+	assertEquals "first second" "$keys"
+
+	set -u
+}
+
 . ./shunit2/shunit2


### PR DESCRIPTION
### tests: shunit2: add test for _jshn_append via JSON script

Add another test which verifies _jshn_append leading space fix in commit
82cb5fd66af9 ("libubox: Drop extraneous space when appending values to
variable") by appending keys to JSON objects, making sure there is no
leading space on the first key when adding second key.

```shell
  test_jshn_append_via_json_script
  ASSERT:expected:<first> but was:< first>
  ASSERT:expected:<first second> but was:< first second>
```

Tests: #16

### tests: shunit2: add bash shebang to fix export -n error in dash

The test script was missing a shebang, causing it to be executed with
/bin/sh (often dash on Debian/Ubuntu systems). When the test sources
jshn.sh, which uses 'export -n', dash fails with:

```shell
  libubox/tests/shunit2/tests.sh: 125: export: Illegal option -n
```

Fix it by adding bash shebang.

---

https://github.com/ynezz/openwrt-libubox/actions/runs/19331703870/job/55296135170#step:9:34

<details><summary>Test results with 82cb5fd66af9 fix reverted</summary>

```shell
Run make test CTEST_OUTPUT_ON_FAILURE=1
Running tests...
Test project /home/runner/work/openwrt-libubox/openwrt-libubox
    Start 1: cram
1/2 Test #1: cram .............................   Passed   45.61 sec
    Start 2: shunit2
2/2 Test #2: shunit2 ..........................***Failed    0.20 sec
#
# Performing tests
#
test_bad_json
test_expr_eq
test_expr_has
test_expr_regex_single
test_expr_regex_multi
test_expr_not
test_expr_and
test_expr_or
test_expr_isdir
test_cmd_case
test_cmd_if
test_cmd_cb
test_cmd_return
test_jshn_append_no_leading_space
ASSERT:expected:<foo> but was:< foo>
ASSERT:expected:<first second> but was:< first second>
test_jshn_append_via_json_script
ASSERT:expected:<first> but was:< first>
ASSERT:expected:<first second> but was:< first second>

#
# Test report
#
tests passed:     1  20%
tests failed:     4  80%
tests skipped:    0   0%
tests total:      5 100%

Errors while running CTest

50% tests passed, 1 tests failed out of 2

Total Test time (real) =  45.81 sec

The following tests FAILED:
	  2 - shunit2 (Failed)
make: *** [Makefile:71: test] Error 8
```

</details> 