### PR TITLE
libubox: Add ability to find ordinal position inside a table

### DIFF
--- a/sh/jshn.sh
+++ b/sh/jshn.sh
@@ -197,6 +197,20 @@ json_add_fields() {
 	done
 }
 
+json_get_index() {
+	local __dest="$1"
+	local __cur __parent __seq
+	_json_get_var __cur JSON_CUR
+	_json_get_var __parent "U_$__cur"
+	if [ "${__parent%%[0-9]*}" != "J_A" ]; then
+		[ -n "$_json_no_warning" ] || \
+			echo "WARNING: Not inside an array" >&2
+		return 1
+	fi
+	__seq="S_$__parent"
+	eval "export -- \"$__dest=\${$__seq}\"; [ -n \"\${$__seq+x}\" ]"
+}
+
 # functions read access to json variables
 
 json_compact() {

--- a/tests/shunit2/tests.sh
+++ b/tests/shunit2/tests.sh
@@ -469,6 +469,43 @@ test_jshn_append_via_json_script() {
 	json_add_string "second" "value2"
 	json_get_keys keys
 	assertEquals "first second" "$keys"
+	set -u
+}
+
+test_jshn_get_index() {
+	JSON_PREFIX="${JSON_PREFIX:-}"
+	. ../../sh/jshn.sh
+
+	set +u
+
+	local index
+
+	json_init
+
+	json_add_object "DHCP4"
+
+	json_add_array "networks"
+
+	json_add_object ""
+	json_get_index index
+	json_add_int "id" 1
+	json_add_string "subnet" "192.168.1.0/24"
+	json_close_object
+
+	json_add_object ""
+	json_add_int "id" 2
+	json_add_string "subnet" "192.168.2.0/24"
+	json_close_object
+
+	json_select "$index" # revisit first anonymous object
+	json_add_int "valid-lifetime" 3600
+	json_select .. # pop back into array
+
+	json_close_array # networks
+
+	json_close_object # DHCP4
+
+	assertEquals '{ "DHCP4": { "networks": [ { "id": 1, "subnet": "192.168.1.0\/24", "valid-lifetime": 3600 }, { "id": 2, "subnet": "192.168.2.0\/24" } ] } }' "$(json_dump)"
 
 	set -u
 }


### PR DESCRIPTION
When adding anonymous objects to an array, the only way to select them (as in `json_select`) is via their ordinality.  This function returns a selectable index to those members.