### PR TITLE
build: install libubox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,7 @@ jobs:
           mkdir -p ${GITHUB_WORKSPACE}/build
           mkdir -p ${GITHUB_WORKSPACE}/depends/lua
           echo "${GITHUB_WORKSPACE}/build/bin" >> $GITHUB_PATH
+          echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/build/lib:${{ env.LD_LIBRARY_PATH }}" >> $GITHUB_ENV
 
       - name: Build json-c
         working-directory: depends/json-c
@@ -230,8 +231,10 @@ jobs:
             -DBUILD_EXAMPLES=ON \
             -DUNIT_TESTING=ON \
             -DLUAPATH=${GITHUB_WORKSPACE}/build/lib/lua \
+            --install-prefix ${GITHUB_WORKSPACE}/build \
             -B . -S .
           make
+          make install
 
       - name: Test libubox
         run: |

--- a/scripts/devel-build.sh
+++ b/scripts/devel-build.sh
@@ -23,6 +23,10 @@ DEPSDIR="${BUILDDIR}/depends"
 [ -e "${BUILDDIR}" ] || mkdir "${BUILDDIR}"
 [ -e "${DEPSDIR}" ] || mkdir "${DEPSDIR}"
 
+# Prepare env
+export LD_LIBRARY_PATH="${BUILDDIR}/lib:${LD_LIBRARY_PATH:-}"
+export PATH="${BUILDDIR}/bin:${PATH:-}"
+
 # Download deps
 cd "${DEPSDIR}"
 [ -e "json-c" ] || git clone https://github.com/json-c/json-c.git
@@ -58,8 +62,13 @@ cmake							\
 	-S .						\
 	-B "${BUILDDIR}"				\
 	-DCMAKE_PREFIX_PATH="${BUILDDIR}"		\
+	--install-prefix "${BUILDDIR}"			\
 	${BUILD_ARGS}
-make -C "${BUILDDIR}" all test CTEST_OUTPUT_ON_FAILURE=1
+make -C "${BUILDDIR}"
+make -C "${BUILDDIR}" install
+
+# Test libubox
+make -C "${BUILDDIR}" test CTEST_OUTPUT_ON_FAILURE=1
 
 set +x
 echo "✅ Success - the libubox library is available at ${BUILDDIR}"


### PR DESCRIPTION
Install libubox and properly use it by adding it to PATH and LD_LIBRARY_PATH.
This is needed for tests using `jshn`.