### PR TITLE
uloop: add ULOOP_PRIORITY support for EPOLLPRI events

### DIFF
--- a/uloop-epoll.c
+++ b/uloop-epoll.c
@@ -52,6 +52,9 @@ static int register_poll(struct uloop_fd *fd, unsigned int flags)
 	if (flags & ULOOP_EDGE_TRIGGER)
 		ev.events |= EPOLLET;
 
+	if (flags & ULOOP_PRIORITY)
+		ev.events |= EPOLLPRI;
+
 	ev.data.ptr = fd;
 
 	return epoll_ctl(poll_fd, op, fd->fd, &ev);
@@ -85,7 +88,7 @@ static int uloop_fetch_events(int timeout)
 				uloop_fd_delete(u);
 		}
 
-		if(!(events[n].events & (EPOLLRDHUP|EPOLLIN|EPOLLOUT|EPOLLERR|EPOLLHUP))) {
+		if(!(events[n].events & (EPOLLRDHUP|EPOLLIN|EPOLLOUT|EPOLLERR|EPOLLHUP|EPOLLPRI))) {
 			cur->fd = NULL;
 			continue;
 		}
@@ -98,6 +101,9 @@ static int uloop_fetch_events(int timeout)
 
 		if(events[n].events & EPOLLOUT)
 			ev |= ULOOP_WRITE;
+
+		if(events[n].events & EPOLLPRI)
+			ev |= ULOOP_PRIORITY;
 
 		cur->events = ev;
 	}

--- a/uloop.c
+++ b/uloop.c
@@ -238,7 +238,7 @@ int uloop_fd_add(struct uloop_fd *sock, unsigned int flags)
 	unsigned int fl;
 	int ret;
 
-	if (!(flags & (ULOOP_READ | ULOOP_WRITE)))
+	if (!(flags & (ULOOP_READ | ULOOP_WRITE | ULOOP_PRIORITY)))
 		return uloop_fd_delete(sock);
 
 	if (!sock->registered && !(flags & ULOOP_BLOCKING)) {

--- a/uloop.h
+++ b/uloop.h
@@ -49,8 +49,6 @@ typedef void (*uloop_signal_handler)(struct uloop_signal *s);
 #define ULOOP_EDGE_TRIGGER	(1 << 2)
 #define ULOOP_BLOCKING		(1 << 3)
 
-#define ULOOP_EVENT_MASK	(ULOOP_READ | ULOOP_WRITE)
-
 /* internal flags */
 #define ULOOP_EVENT_BUFFERED	(1 << 4)
 #ifdef USE_KQUEUE
@@ -58,6 +56,9 @@ typedef void (*uloop_signal_handler)(struct uloop_signal *s);
 #endif
 
 #define ULOOP_ERROR_CB		(1 << 6)
+#define ULOOP_PRIORITY		(1 << 7)
+
+#define ULOOP_EVENT_MASK	(ULOOP_READ | ULOOP_WRITE | ULOOP_PRIORITY)
 
 struct uloop_fd
 {


### PR DESCRIPTION
Add a new ULOOP_PRIORITY flag to enable subscription to and delivery of EPOLLPRI events from the Linux kernel.

These interfaces include:

- /proc/pressure/{cpu,memory,io} — PSI threshold monitoring
- /proc/mounts — mount/unmount change notifications
- /proc/mdstat — software RAID state changes
- sysfs attributes using sysfs_notify() (GPIO, hwmon, etc.)

This would be a linux only feature. `ULOOP_PRIORITY` is an alright name. If someone can think of something better let me know. 