### PR TITLE
uloop: use volatile sig_atomic_t for uloop_cancelled and uloop_status

### DIFF
--- a/uloop.c
+++ b/uloop.c
@@ -61,9 +61,9 @@ static struct list_head processes = LIST_HEAD_INIT(processes);
 static struct list_head signals = LIST_HEAD_INIT(signals);
 
 static int poll_fd = -1;
-bool uloop_cancelled = false;
+volatile sig_atomic_t uloop_cancelled = 0;
 bool uloop_handle_sigchld = true;
-static int uloop_status = 0;
+static volatile sig_atomic_t uloop_status = 0;
 static volatile sig_atomic_t do_sigchld = 0;
 
 static struct uloop_fd_event cur_fds[ULOOP_MAX_EVENTS];
@@ -670,7 +670,7 @@ int uloop_run_timeout(int timeout)
 	uloop_run_depth++;
 
 	uloop_status = 0;
-	uloop_cancelled = false;
+	uloop_cancelled = 0;
 	do {
 		uloop_process_timeouts();
 

--- a/uloop.h
+++ b/uloop.h
@@ -112,7 +112,7 @@ struct uloop_signal
 	int signo;
 };
 
-extern bool uloop_cancelled;
+extern volatile sig_atomic_t uloop_cancelled;
 extern bool uloop_handle_sigchld;
 extern uloop_fd_handler uloop_fd_set_cb;
 
@@ -140,7 +140,7 @@ bool uloop_cancelling(void);
 
 static inline void uloop_end(void)
 {
-	uloop_cancelled = true;
+	uloop_cancelled = 1;
 }
 
 int uloop_init(void);


### PR DESCRIPTION
Both variables are written from signal handlers (uloop_handle_sigint) and read from the main loop. Using plain bool/int without volatile sig_atomic_t is a data race and undefined behavior. This matches the fix already applied to do_sigchld.