### PR TITLE
Revert "utils: fix integer overflow in __calloc_a()"

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -38,28 +38,14 @@ void *__calloc_a(size_t len, ...)
 	void *ret;
 	void **cur_addr;
 	size_t cur_len;
-	size_t alloc_len = 0;
+	int alloc_len = 0;
 	char *ptr;
 
 	va_start(ap, len);
 
 	va_copy(ap1, ap);
-	foreach_arg(ap1, cur_addr, cur_len, &ret, len) {
-		size_t aligned;
-
-		if (cur_len > SIZE_MAX - (C_PTR_ALIGN - 1)) {
-			va_end(ap1);
-			va_end(ap);
-			return NULL;
-		}
-		aligned = (cur_len + C_PTR_ALIGN - 1) & C_PTR_MASK;
-		if (aligned > SIZE_MAX - alloc_len) {
-			va_end(ap1);
-			va_end(ap);
-			return NULL;
-		}
-		alloc_len += aligned;
-	}
+	foreach_arg(ap1, cur_addr, cur_len, &ret, len)
+		alloc_len += (cur_len + C_PTR_ALIGN - 1 ) & C_PTR_MASK;
 	va_end(ap1);
 
 	ptr = calloc(1, alloc_len);


### PR DESCRIPTION
This reverts commit 9b488010c4a74202a85ed24e01108fe069bd42e4.

[Symptoms]
1. MediaTek Filogic Platform: When simultaneously accessing more than 15 URLs, uhttpd immediately enters a crash loop:
```
daemon.info: procd: Instance uhttpd::instance1 s in a crash loop 6 crashes, 8 seconds since last crash
```
2. x86_64 Platform: Although it does not crash under high concurrency, the response time for requests is significantly prolonged, leading to a drastic drop in system throughput.