### PR TITLE
lua: build: link against liblua

### DIFF
--- a/lua/CMakeLists.txt
+++ b/lua/CMakeLists.txt
@@ -34,7 +34,7 @@ IF(BUILD_LUA)
 		OUTPUT_NAME uloop
 		PREFIX ""
 	)
-	TARGET_LINK_LIBRARIES(uloop_lua ubox)
+	TARGET_LINK_LIBRARIES(uloop_lua ubox lua)
 
 	INSTALL(TARGETS uloop_lua
 		LIBRARY DESTINATION ${LUAPATH}


### PR DESCRIPTION
@hauke 
ldd reports many errors regarding missing symbols because the library is not linked against liblua.

```
root@openwrt ~ # ldd /usr/lib/lua/uloop.so 
        ldd (0x7faa5a0000)
        libubox.so.20260213 => /lib/libubox.so.20260213 (0x7faa62c000)
        libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x7faa56f000)
        libc.so => ldd (0x7faa5a0000)
Error relocating /usr/lib/lua/uloop.so: lua_touserdata: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_isnumber: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_ref: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_openlib: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_objlen: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_getfield: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_unref: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_tointeger: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushnumber: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_remove: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_setfield: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_isstring: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushvalue: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushnil: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_error: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_tonumber: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_settop: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushcclosure: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_tolstring: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_type: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushboolean: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_settable: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_setmetatable: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_newuserdata: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_call: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_error: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushstring: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_checkinteger: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_rawgeti: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_rawset: symbol not found
Error relocating /usr/lib/lua/uloop.so: luaL_checktype: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_createtable: symbol not found
Error relocating /usr/lib/lua/uloop.so: lua_pushinteger: symbol not found
root@openwrt ~ #
```

We have to link the lua uloop library against liblua.