### PR TITLE
blobmsg: use flexible-array member in blobmsg_name()

### DIFF
--- a/blobmsg.h
+++ b/blobmsg.h
@@ -62,7 +62,7 @@ static inline void blobmsg_clear_name(struct blob_attr *attr)
 static inline const char *blobmsg_name(const struct blob_attr *attr)
 {
 	struct blobmsg_hdr *hdr = (struct blobmsg_hdr *) blob_data(attr);
-	return (const char *)(hdr + 1);
+	return (const char *)hdr->name;
 }
 
 static inline int blobmsg_type(const struct blob_attr *attr)


### PR DESCRIPTION
### Problem

\`blobmsg_name()\` currently returns \`(const char *)(hdr + 1)\`, a pointer to the byte immediately after \`struct blobmsg_hdr\`. GCC's \`__builtin_object_size\` treats that region as size 0, so any caller passing the result to a string function (\`strcmp\`, \`strlen\`, \`strchr\`, …) under \`-Wall -Wstringop-overread\` gets a false-positive diagnostic.

Concrete example: building \`uhttpd\` (which uses \`-Wall -Werror\` in its CMakeLists.txt) on aarch64 glibc with GCC 12.3.0 fails:

\`\`\`
client.c:302:22: error: 'strcmp' reading 1 or more bytes from a region of size 0
    [-Werror=stringop-overread]
  302 |    if (!strcmp(blobmsg_name(cur), "URL"))
\`\`\`

### Fix

Return \`hdr->name\` (the flexible-array member) instead of \`(hdr + 1)\`. GCC treats flexible arrays as having unknown size, so the false positive disappears. The resulting pointer value is identical - purely a source-level change.

No behavioral change, no ABI change.