### PR TITLE
uloop: timeval boundary check

### DIFF
--- a/blobmsg.h
+++ b/blobmsg.h
@@ -70,7 +70,7 @@ static inline int blobmsg_type(const struct blob_attr *attr)
 	return blob_id(attr);
 }
 
-static uint16_t blobmsg_namelen(const struct blobmsg_hdr *hdr)
+static inline uint16_t blobmsg_namelen(const struct blobmsg_hdr *hdr)
 {
 	return be16_to_cpu(hdr->namelen);
 }

--- a/uloop.c
+++ b/uloop.c
@@ -366,7 +366,7 @@ int uloop_timeout_set(struct uloop_timeout *timeout, int msecs)
 	time->tv_sec += msecs / 1000;
 	time->tv_usec += (msecs % 1000) * 1000;
 
-	if (time->tv_usec > 1000000) {
+	if (time->tv_usec >= 1000000) {
 		time->tv_sec++;
 		time->tv_usec -= 1000000;
 	}


### PR DESCRIPTION
tv_usec range should be [0, 999], then when tv_usec not less than 1000, need to update tv_sec