### PR TITLE
uloop: fix timeval boundary check

### DIFF
--- a/uloop.c
+++ b/uloop.c
@@ -366,7 +366,7 @@ int uloop_timeout_set(struct uloop_timeout *timeout, int msecs)
 	time->tv_sec += msecs / 1000;
 	time->tv_usec += (msecs % 1000) * 1000;
 
-	if (time->tv_usec > 1000000) {
+	if (time->tv_usec >= 1000000) {
 		time->tv_sec++;
 		time->tv_usec -= 1000000;
 	}


### PR DESCRIPTION
tv_usec range should be [0, 999999], then when tv_usec not less than 1000000, need to update tv_sec